### PR TITLE
Use superagent instead of supertest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ In some situations, the `get()` function might be called more than once per endp
 
 ## Logging
 The library use `debug` for logging. To see logs, set this environment variable: `DEBUG=riot-lol-api:*`.
+
+## Errors
+Errors when trying to read the cache are forwarded directly to the requester.
+
+HTTP errrors on the Riot API side will expose two properties:
+
+* `.statusCode` containing the return code from the API (the most common one is 503. Note that the library is retrying by default all 5XX errors, so if you see it in your code it means that the error happened twice)
+* `riotInternal` a flag set to true to help you distinguish network errors (fairly common) from more standard errors (e.g. from your cache)

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,7 @@ RiotRequest.prototype.generateQueue = function generateQueue(region) {
           // Mirror actual status code on the error
           if(err && err.status) {
             err.statusCode = err.status;
+            err.riotInternal = true;
 
             // 500 on Riot side, let's try again just in case this is temporary
             if((err.status === 500 || err.status === 503) && !task.restartedAfter500) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var async = require("async");
-var supertest = require("supertest");
+var superagent = require("superagent");
 var rarity = require("rarity");
 var log = require("debug")("riot-lol-api:request");
 
@@ -77,10 +77,9 @@ RiotRequest.prototype.generateQueue = function generateQueue(region) {
 
       secondaryLog("Loading from network " + task.region + ":" + task.endpoint);
 
-      supertest("https://" + task.region + ".api.pvp.net")
-        .get(task.endpoint + (task.endpoint.indexOf("?") === -1 ? "?" : "&") + "api_key=" + self.apiKey)
+      superagent
+        .get("https://" + task.region + ".api.pvp.net" + task.endpoint + (task.endpoint.indexOf("?") === -1 ? "?" : "&") + "api_key=" + self.apiKey)
         .timeout(2500)
-        .expect(200)
         .end(function(err, res) {
           if(res && res.headers && res.headers['x-rate-limit-count']) {
             var rateInfo = res.headers['x-rate-limit-count'].split(',');
@@ -105,7 +104,7 @@ RiotRequest.prototype.generateQueue = function generateQueue(region) {
               // secondaryLog("New concurrency for " + task.region + ": " + availableConcurrency);
             }
           }
-          if(err && res && res.statusCode === 429) {
+          if(err && err.status === 429) {
             // Rate limited :(
             // We'll retry later.
             requestQueue.concurrency = 1;
@@ -127,13 +126,13 @@ RiotRequest.prototype.generateQueue = function generateQueue(region) {
           }
 
           // Mirror actual status code on the error
-          if(err && res && res.statusCode) {
-            err.statusCode = res.statusCode;
+          if(err && err.status) {
+            err.statusCode = err.status;
 
             // 500 on Riot side, let's try again just in case this is temporary
-            if((res.statusCode === 500 || res.statusCode === 503) && !task.restartedAfter500) {
+            if((err.status === 500 || err.status === 503) && !task.restartedAfter500) {
               task.restartedAfter500 = true;
-              secondaryLog("Got a " + res.statusCode + " on " + task.endpoint + ", will try again.");
+              secondaryLog("Got a " + err.status + " on " + task.endpoint + ", will try again.");
               setTimeout(function() {
                 queueWorker(task, cb);
               }, 25);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-lol-api",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Small helper to handle Riot API rate limiting and server errors",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debug": "^2.4.5",
     "rarity": "^2.1.1",
     "request": "^2.73.0",
-    "supertest": "^2.0.1"
+    "superagent": "^3.3.1"
   },
   "devDependencies": {
     "jscs": "^3.0.7",
@@ -31,7 +31,8 @@
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.12.1",
     "nock": "^7.2.2",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.4",
+    "supertest": "^2.0.1"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
I'm fed up with seeing "cannot read property status" for any error.
See https://github.com/visionmedia/supertest/issues/352

I want my error reporting to be clear, concise and coherent, not just display the same message every time something different happens.

This move supertest to the devDependencies only, and use superagent for the actual HTTP calls outside of the test suite.