### PR TITLE
Add support for external options + expose defaultRetryPeriod

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ riotRequest.request('euw1', 'champion-mastery', '/lol/champion-mastery/v3/champi
 riotRequest.request('euw1', 'league', '/lol/league/v3/positions/by-summoner/4203456', function(err, data) {});
 ```
 
+## Settings
+The `RiotRequest` constructure has a third parameter that is used to pass options.\
+Here is a list of available options:\
+* `defaultRetryPeriod` (Default: 10) - The retry period to use if the `Retry-After` header is not present (Numeric).
+
 ## Logging
 The library use `debug` for logging. To see logs, set this environment variable: `DEBUG=riot-lol-api:*`.
 
@@ -111,7 +116,7 @@ Honestly, skip this section if you're using the library for the first time. I st
 Use case:
 
 * throttle some process to ensure other processes always have enough requests available.
- 
+
 Let's say you have a worker downloading games in the background, and you also have a frontend that can request games from the API in realtime to answer user requests. You always want the frontend to be able to request in realtime, but by default it's very likely your worker will use all capacity every 10s.
 To prevent this, the library exposes a method named `setThrottle(platform, method, throttle)` (and `setThrottle(method, throttle)` which is automatically applied to all platforms).
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ riotRequest.request('euw1', 'league', '/lol/league/v3/positions/by-summoner/4203
 ```
 
 ## Settings
-The `RiotRequest` constructure has a third parameter that is used to pass options.\
+The `RiotRequest` constructor has a third parameter that is used to pass options.\
 Here is a list of available options:\
 * `defaultRetryPeriod` (Default: 10) - The retry period to use if the `Retry-After` header is not present (Numeric).
 
@@ -116,7 +116,7 @@ Honestly, skip this section if you're using the library for the first time. I st
 Use case:
 
 * throttle some process to ensure other processes always have enough requests available.
-
+ 
 Let's say you have a worker downloading games in the background, and you also have a frontend that can request games from the API in realtime to answer user requests. You always want the frontend to be able to request in realtime, but by default it's very likely your worker will use all capacity every 10s.
 To prevent this, the library exposes a method named `setThrottle(platform, method, throttle)` (and `setThrottle(method, throttle)` which is automatically applied to all platforms).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var keepaliveAgent = new Agent();
  * Ratelimits will default to a development api key (very slow)
  * Cache must be an object exposing both get() and set() methods
  */
-var RiotRequest = function(apiKey, cache) {
+var RiotRequest = function(apiKey, cache, options) {
   if (!apiKey) {
     throw new Error('Missing Riot API key.');
   }
@@ -45,6 +45,20 @@ var RiotRequest = function(apiKey, cache) {
 
   // Will contain all the queues (one per couple platform/method)
   this.requestQueues = {};
+
+  // Populate options object
+  if (!(options instanceof Object)) {
+    options = {};
+  }
+  const defaultOptions = {
+    defaultRetryPeriod: 10
+  };
+  Object.entries(defaultOptions).forEach(([k, v]) => {
+    if (!options.hasOwnProperty(k)) {
+      options[k] = v;
+    }
+  });
+  this.options = options;
 };
 
 RiotRequest.prototype.generateQueue = function generateQueue(platform, method) {
@@ -143,7 +157,7 @@ RiotRequest.prototype.generateQueue = function generateQueue(platform, method) {
             // Rate limited :(
             // We'll retry later.
             requestQueue.concurrency = 0;
-            var retryAfter = (res.headers['retry-after'] || 2) * 1000;
+            var retryAfter = (res.headers['retry-after'] || self.options.defaultRetryPeriod) * 1000;
             requestQueue.rateLimited = true;
             secondaryLog(`Rate limited, will retry in ${retryAfter} (pending requests: ${requestQueue.length() + 1})`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-lol-api",
-  "version": "4.2.18",
+  "version": "4.3.0",
   "description": "Small helper to handle Riot API rate limiting and server errors",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This PR exposes an `options` object as part of the constructor parameters and sets default settings if they are missing.
This PR also exposes the default retry period if the `Retry-After` header is missing.

**Note:** I'm not too sure how to test this library so we should add test notes for future developers 😄
**Another Note:** The only thing I don't like about this is the fact that cache has to be configured before passing options, even though simply passing false if you don't want to cache should be sufficient.

This PR Closes issue #26  