### PR TITLE
replaced Object.values

### DIFF
--- a/lib/regions.js
+++ b/lib/regions.js
@@ -21,4 +21,6 @@ module.exports = function getPlatform(region) {
 };
 
 module.exports.REGIONS = Object.keys(PLATFORMS);
-module.exports.PLATFORMS = Object.values(PLATFORMS);
+module.exports.PLATFORMS = Object.keys(PLATFORMS).map(function(key){
+  return PLATFORMS[key];
+});


### PR DESCRIPTION
Object.values breaks sometimes because it's not always supported in node. This is a bit uglier but always works.

in my case, it would crash immediately:

    TypeError: Object.values is not a function
    at Object.<anonymous> (./node_modules/riot-lol-api/lib/regions.js:24:35)